### PR TITLE
Make app configurable

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,211 @@
+const Config = require('../lib/config')
+
+describe('config', function () {
+  const defaultConfig = new Config()
+
+  test('roles label text', () => {
+    let options, config, author, expected
+
+    // defaults
+    expected = [
+      'stalebot/waiting-for/author',
+      'stalebot/waiting-for/maintainer'
+    ]
+    expect(defaultConfig.roles.labels().sort()).toEqual(expected)
+
+    // override namespace
+    options = {namespace: 'override'}
+    config = new Config(options)
+    expected = [
+      'override/waiting-for/author',
+      'override/waiting-for/maintainer'
+    ]
+    expect(config.roles.labels().sort()).toEqual(expected)
+
+    // override prefix for label set
+    options = {
+      roles: {
+        prefix: 'override'
+      }
+    }
+    config = new Config(options)
+    expected = [
+      'stalebot/override/author',
+      'stalebot/override/maintainer'
+    ]
+    expect(config.roles.labels().sort()).toEqual(expected)
+
+    // override individual label value
+    options = {
+      roles: {
+        author: {name: 'original-poster'}
+      }
+    }
+    config = new Config(options)
+    author = config.roles.find({role: 'author'})
+    expect(author.name).toEqual('stalebot/waiting-for/original-poster')
+  })
+
+  test('roles label color', () => {
+    let options, config, author, maintainer
+
+    // defaults to default label color
+    author = defaultConfig.roles.find({role: 'author'})
+    maintainer = defaultConfig.roles.find({role: 'maintainer'})
+    expect(author.color).toEqual('cccccc')
+    expect(maintainer.color).toEqual('cccccc')
+
+    // defaults to overridden default label color
+    options = {
+      defaultColor: 'ffffff'
+    }
+    config = new Config(options)
+    author = config.roles.find({role: 'author'})
+    maintainer = config.roles.find({role: 'maintainer'})
+    expect(author.color).toEqual('ffffff')
+    expect(maintainer.color).toEqual('ffffff')
+
+    // can override individual label color
+    options = {
+      roles: {
+        maintainer: {color: '000000'}
+      }
+    }
+    config = new Config(options)
+    maintainer = config.roles.find({role: 'maintainer'})
+    expect(maintainer.color).toEqual('000000')
+  })
+
+  test('escalation label values', () => {
+    let options, config, expected
+
+    expected = [
+      'stalebot/status/dire',
+      'stalebot/status/fresh',
+      'stalebot/status/needs-attention',
+      'stalebot/status/stale'
+    ]
+    expect(defaultConfig.escalation.labels().sort()).toEqual(expected)
+
+    // override namespace
+    options = {namespace: 'override'}
+    config = new Config(options)
+    expected = [
+      'override/status/dire',
+      'override/status/fresh',
+      'override/status/needs-attention',
+      'override/status/stale'
+    ]
+    expect(config.escalation.labels().sort()).toEqual(expected)
+
+    // override prefix for label set
+    options = {
+      escalation: {
+        prefix: 'override'
+      }
+    }
+    config = new Config(options)
+    expected = [
+      'stalebot/override/dire',
+      'stalebot/override/fresh',
+      'stalebot/override/needs-attention',
+      'stalebot/override/stale'
+    ]
+    expect(config.escalation.labels().sort()).toEqual(expected)
+
+    // override entire label set
+    options = {
+      escalation: {
+        levels: [
+          {name: 'good'},
+          {name: 'ok'},
+          {name: 'bad'}
+        ]
+      }
+    }
+    config = new Config(options)
+    expect(config.escalation.labels().length).toEqual(3)
+
+    let good = config.escalation.find({level: 0})
+    let ok = config.escalation.find({level: 1})
+    let bad = config.escalation.find({level: 2})
+    expect(good.name).toEqual('stalebot/status/good')
+    expect(ok.name).toEqual('stalebot/status/ok')
+    expect(bad.name).toEqual('stalebot/status/bad')
+  })
+
+  test('escalation label color', () => {
+    let options, config, label
+
+    // defaults to default labels with default label color
+    label = defaultConfig.escalation.find({level: 0})
+    expect(label.color).toEqual('5dcc77')
+
+    // when overriding label set, defaults to defined defaultColor
+    options = {
+      defaultColor: 'ffffff',
+      escalation: {
+        levels: [
+          {name: 'fresh'},
+          {name: 'needs-attention'},
+          {name: 'stale'},
+          {name: 'dire'}
+        ]
+      }
+    }
+    config = new Config(options)
+    config.escalation.values.forEach(value => {
+      expect(value.color).toEqual('ffffff')
+    })
+
+    // can set color when overriding
+    options = {
+      escalation: {
+        levels: [
+          {name: 'good', color: 'ffffff'},
+          {name: 'ok', color: '999999'},
+          {name: 'bad', color: '333333'}
+        ]
+      }
+    }
+    config = new Config(options)
+    let good = config.escalation.find({level: 0})
+    let ok = config.escalation.find({level: 1})
+    let bad = config.escalation.find({level: 2})
+    expect(good.color).toEqual('ffffff')
+    expect(ok.color).toEqual('999999')
+    expect(bad.color).toEqual('333333')
+  })
+
+  test('escalation thresholds', () => {
+    // has default thresholds
+    defaultConfig.escalation.values.forEach(value => {
+      expect(value.threshold).toBeDefined()
+    })
+
+    // If someone overrides levels without setting thresholds
+    // then we need to define something.
+    // For now I'm making it grow exponentially.
+    let options = {
+      escalation: {
+        levels: [
+          {name: 'great'},
+          {name: 'good'},
+          {name: 'cool'},
+          {name: 'meh'},
+          {name: 'hmm'},
+          {name: 'blech'},
+          {name: 'cmon'},
+          {name: 'freal'},
+          {name: 'goddammit'},
+          {name: 'wtf'}
+        ]
+      }
+    }
+    let config = new Config(options)
+
+    for (let i = 0; i < config.escalation.values.length; i++) {
+      expect(config.escalation.values[i].threshold).toBeDefined()
+    }
+  })
+})

--- a/__tests__/label_set.test.js
+++ b/__tests__/label_set.test.js
@@ -1,0 +1,97 @@
+const LabelSet = require('../lib/label_set')
+
+describe('label sets', function () {
+  function byName (a, b) {
+    if (a.name > b.name) {
+      return 1
+    }
+    if (a.name < b.name) {
+      return -1
+    }
+    return 0
+  }
+
+  test('a simple set', () => {
+    const options = {
+      namespace: 'alphabet',
+      defaultColor: 'cccccc',
+      key: 'fruit',
+      prefix: 'letters',
+      values: [
+        {name: 'a', fruit: 'apple'},
+        {name: 'b', fruit: 'banana'}
+      ]
+    }
+
+    let set = new LabelSet(options)
+    expect(set.labels().sort(byName)).toEqual(['alphabet/letters/a', 'alphabet/letters/b'])
+
+    let label = set.label({fruit: 'apple'})
+    expect(label).toEqual('alphabet/letters/a')
+
+    label = set.find({fruit: 'banana'})
+    expect(label.name).toEqual('alphabet/letters/b')
+    expect(label.color).toEqual('cccccc')
+
+    expect(set.prefix).toEqual('alphabet/letters')
+  })
+
+  test('set keeps values beyond color, name, and lookup key', () => {
+    const options = {
+      namespace: 'namespace',
+      prefix: 'prefix',
+      key: 'lookup',
+      values: [
+        {name: 'apple', lookup: 'a', garbage: 'nonsense'},
+        {name: 'banana', lookup: 'b', garbage: 'whatever'}
+      ]
+    }
+
+    let set = new LabelSet(options)
+    let a = set.find({lookup: 'a'})
+    let b = set.find({lookup: 'b'})
+    expect(a.garbage).toEqual('nonsense')
+    expect(b.garbage).toEqual('whatever')
+  })
+
+  test('set with numeric lookup', () => {
+    const options = {
+      namespace: 'a',
+      prefix: 'b',
+      defaultColor: 'cccccc',
+      key: 'stars',
+      values: [
+        {name: 'sucks', stars: 0},
+        {name: 'rocks', stars: 1}
+      ]
+    }
+
+    let set = new LabelSet(options)
+
+    expect(set.labels().sort(byName)).toEqual(['a/b/sucks', 'a/b/rocks'])
+
+    let label = set.find({stars: 0})
+    expect(label.name).toEqual('a/b/sucks')
+    expect(label.color).toEqual('cccccc')
+  })
+
+  test('venn diagram', () => {
+    let set = new LabelSet({
+      namespace: 'L',
+      key: 'level',
+      prefix: 'levels',
+      values: [
+        {name: 'a'},
+        {name: 'b'},
+        {name: 'c'},
+        {name: 'd'}
+      ]
+    })
+
+    let labels = set.intersection(['a', 'L/levels/b', 'c', 'L/levels/d'])
+    expect(labels).toEqual(['L/levels/b', 'L/levels/d'])
+
+    labels = set.missing(['a', 'L/levels/b', 'c', 'L/levels/d'])
+    expect(labels).toEqual(['L/levels/a', 'L/levels/c'])
+  })
+})

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,65 @@
+const LabelSet = require('./label_set')
+
+module.exports = class Config {
+  constructor (options) {
+    options = options || {}
+
+    options.namespace = options.namespace || 'stalebot'
+    options.defaultColor = options.defaultColor || 'cccccc'
+
+    options.roles = options.roles || {}
+    options.roles.author = options.roles.author || {}
+    options.roles.maintainer = options.roles.maintainer || {}
+
+    let attributes = {
+      namespace: options.namespace,
+      defaultColor: options.defaultColor,
+      key: 'role',
+      prefix: options.roles.prefix || 'waiting-for',
+      values: [
+        {
+          role: 'author',
+          name: options.roles.author.name || 'author',
+          color: options.roles.author.color || options.defaultColor
+        },
+        {
+          role: 'maintainer',
+          name: options.roles.maintainer.name || 'maintainer',
+          color: options.roles.maintainer.color || options.defaultColor
+        }
+      ]
+    }
+    this.roles = new LabelSet(attributes)
+
+    const dayInSeconds = 24 * 60 * 60
+    const defaultEscalationLevels = [
+      {color: '5dcc77', threshold: 0 * dayInSeconds, name: 'fresh'},
+      {color: 'f9dc5c', threshold: 1 * dayInSeconds, name: 'needs-attention'},
+      {color: 'ff8552', threshold: 15 * dayInSeconds, name: 'stale'},
+      {color: 'da344d', threshold: 90 * dayInSeconds, name: 'dire'}
+    ]
+
+    options.escalation = options.escalation || {}
+    options.escalation.levels = options.escalation.levels || defaultEscalationLevels
+
+    for (let i = 0; i < options.escalation.levels.length; i++) {
+      let value = options.escalation.levels[i]
+      // add a lookup value
+      value.level = i
+
+      // make sure we have a threshold
+      if (value.threshold === undefined) {
+        value.threshold = (i << i) * dayInSeconds
+      }
+    }
+
+    attributes = {
+      namespace: options.namespace,
+      defaultColor: options.defaultColor,
+      key: 'level',
+      prefix: options.escalation.prefix || 'status',
+      values: options.escalation.levels
+    }
+    this.escalation = new LabelSet(attributes)
+  }
+}

--- a/lib/label_set.js
+++ b/lib/label_set.js
@@ -1,0 +1,66 @@
+module.exports = class LabelSet {
+  constructor (options) {
+    options = options || {}
+
+    this.prefix = [
+      options.namespace || 'stalebot',
+      options.prefix
+    ].join('/')
+
+    this.values = []
+    options.values.forEach(value => {
+      let label = {
+        name: [this.prefix, value.name].join('/'),
+        color: value.color || options.defaultColor || 'cccccc'
+      }
+      if (value[options.key] === undefined) {
+        label[options.key] = value.name
+      } else {
+        label[options.key] = value[options.key]
+      }
+      Object.assign(value, label)
+
+      this.values.push(value)
+    })
+  }
+
+  label (options) {
+    let target = this.find(options)
+    if (target !== undefined) {
+      return target.name
+    }
+  }
+
+  find (options) {
+    if (options === undefined || options.length === 0) {
+      throw new Error('cannot find label without a lookup value')
+    }
+
+    let key = Object.keys(options)[0]
+    for (let i = 0; i < this.values.length; i++) {
+      if (this.values[i][key] === options[key]) {
+        return this.values[i]
+      }
+    }
+  }
+
+  intersection (labels) {
+    return this.labels().filter(label => {
+      return labels.includes(label)
+    })
+  }
+
+  missing (labels) {
+    return this.labels().filter(label => {
+      return !labels.includes(label)
+    })
+  }
+
+  labels () {
+    return this.values.map(this.name)
+  }
+
+  name (value) {
+    return value.name
+  }
+}


### PR DESCRIPTION
We're going to need to make the labels completely configurable in order to follow the Probot best practices. Additionally, I'd like a clean way to get labels that are present in or absent from a list, so that we can make the API call to create/add/remove labels only where necessary.

Commit 1: this creates the underlying datastructure for a "label set". Initially, we're operating with two sets of labels: roles (`maintainer` and `author`), and escalation (by level, with increasing
urgency).
Commit 2: this makes the labels and escalation thresholds configurable, though it doesn't actually check the config in the repo (we're going to need to ask for single file permission).
Commit 3: this updates the app to use the new config for label creation and switching labels for author/maintainer.

I did not change the escalation logic to use the config, since it's verifiably broken (#yolo #demo).

I would love a review in terms of best practices and idioms both for Probot and JavaScript. I've described the config in a comment below, and would like feedback on whether or not that seems reasonable (or reasonable enough for now, perhaps).

@bkeepers would love your thoughts on this one!