### PR TITLE
Fix broken escalation

### DIFF
--- a/__tests__/escalator.test.js
+++ b/__tests__/escalator.test.js
@@ -1,0 +1,130 @@
+const moment = require('moment')
+const Escalator = require('../lib/escalator')
+const Config = require('../lib/config')
+
+describe('escalator', function () {
+  const escalator = new Escalator(new Config())
+
+  test('recent issue', () => {
+    let issue = fakeIssue({at: moment().subtract(1, 'second'), labels: []})
+    let target = escalator.escalate(issue)
+    expect(target.label).toEqual('stalebot/status/fresh')
+  })
+
+  test('day-old issue', () => {
+    let issue = fakeIssue({at: moment().subtract(1, 'days').subtract(1, 'second'), labels: []})
+    let target = escalator.escalate(issue)
+    expect(target.label).toEqual('stalebot/status/needs-attention')
+  })
+
+  test('two-week old issue', () => {
+    let issue = fakeIssue({at: moment().subtract(15, 'days').subtract(1, 'second'), labels: []})
+    let target = escalator.escalate(issue)
+    expect(target.label).toEqual('stalebot/status/stale')
+  })
+
+  test('ridiculously old issue', () => {
+    let issue = fakeIssue({at: moment().subtract(90, 'days').subtract(1, 'second'), labels: []})
+    let target = escalator.escalate(issue)
+    expect(target.label).toEqual('stalebot/status/dire')
+  })
+
+  test('issue with recent author comment', () => {
+    let issue = fakeIssue({at: moment().subtract(100, 'days'), labels: []})
+    let comment = fakeComment({at: moment().subtract(1, 'second')})
+    let target = escalator.escalate(issue, comment)
+    expect(target.label).toEqual('stalebot/status/fresh')
+  })
+
+  test('issue with correct label', () => {
+    let options = {
+      at: moment().subtract(1, 'days').subtract(1, 'second'),
+      labels: ['stalebot/status/needs-attention']
+    }
+    let issue = fakeIssue(options)
+    let expected = {
+      label: 'stalebot/status/needs-attention',
+      add: [],
+      remove: []
+    }
+    expect(escalator.escalate(issue)).toEqual(expected)
+  })
+
+  test('issue with no label', () => {
+    let options = {
+      at: moment().subtract(1, 'days').subtract(1, 'second'),
+      labels: []
+    }
+    let issue = fakeIssue(options)
+    let expected = {
+      label: 'stalebot/status/needs-attention',
+      add: ['stalebot/status/needs-attention'],
+      remove: []
+    }
+    expect(escalator.escalate(issue)).toEqual(expected)
+  })
+
+  test('issue with irrelevant labels', () => {
+    let options = {
+      at: moment().subtract(1, 'days').subtract(1, 'second'),
+      labels: ['bug', 'super-duper-important', 'stalebot/waiting-for/maintainer']
+    }
+    let issue = fakeIssue(options)
+    let expected = {
+      label: 'stalebot/status/needs-attention',
+      add: ['stalebot/status/needs-attention'],
+      remove: []
+    }
+    expect(escalator.escalate(issue)).toEqual(expected)
+  })
+
+  test('issue with wrong label', () => {
+    let options = {
+      at: moment().subtract(1, 'days').subtract(1, 'second'),
+      labels: ['stalebot/status/fresh']
+    }
+    let issue = fakeIssue(options)
+    let expected = {
+      label: 'stalebot/status/needs-attention',
+      add: ['stalebot/status/needs-attention'],
+      remove: ['stalebot/status/fresh']
+    }
+    expect(escalator.escalate(issue)).toEqual(expected)
+  })
+
+  test('issue with several wrong labels', () => {
+    let options = {
+      at: moment().subtract(1, 'days').subtract(1, 'second'),
+      labels: [
+        'stalebot/status/fresh',
+        'stalebot/status/needs-attention', // keep this one
+        'stalebot/status/stale',
+        'stalebot/status/dire'
+      ]
+    }
+    let issue = fakeIssue(options)
+    let expected = {
+      label: 'stalebot/status/needs-attention',
+      add: [],
+      remove: ['stalebot/status/fresh', 'stalebot/status/stale', 'stalebot/status/dire']
+    }
+    expect(escalator.escalate(issue)).toEqual(expected)
+  })
+
+  function fakeIssue (options) {
+    options.labels = options.labels || []
+
+    let issue = {created_at: options.at.toISOString(), labels: []}
+
+    for (let i = 0; i < options.labels.length; i++) {
+      issue.labels.push({id: i + 10, name: options.labels[i], color: 'cccccc'})
+    }
+    return issue
+  }
+
+  function fakeComment (options) {
+    return {
+      created_at: options.at.toISOString()
+    }
+  }
+})

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (robot) => {
 
     const issues = context.github.issues.getForRepo(context.repo({
       state: 'open',
-      label: config.roles.label({role: 'maintainer'}),
+      labels: config.roles.label({role: 'maintainer'}),
       per_page: 100
     }))
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 const createScheduler = require('probot-scheduler')
-const moment = require('moment')
 const Config = require('./lib/config')
+const Escalator = require('./lib/escalator')
 
 module.exports = (robot) => {
   const config = new Config()
+  const escalator = new Escalator(config)
 
   createScheduler(robot)
 
@@ -38,37 +39,19 @@ module.exports = (robot) => {
           })
         })
 
-        let currentLabel = issue.labels.find(label => label.name.startsWith('stalebot/status'))
-        let newLabel
+        let escalation = escalator.escalate(issue, lastAuthorComment)
 
-        const now = new Date()
+        escalation.remove.forEach(async label => {
+          await context.github.issues.removeLabel(context.repo({
+            number: issue.number,
+            name: label
+          }))
+        })
 
-        if (lastAuthorComment) {
-          const lastCommentAt = moment(lastAuthorComment.create_at)
-          const age = now - lastCommentAt / 1000 / 60 / 60 / 24
-
-          if (age >= 90) {
-            newLabel = 'stalebot/status/dire'
-          } else if (age >= 15) {
-            newLabel = 'stalebot/status/stale'
-          } else if (age >= 1) {
-            newLabel = 'stalebot/status/needs-attention'
-          } else {
-            newLabel = 'stalebot/status/fresh'
-          }
-
-          if (currentLabel && currentLabel.name !== newLabel) {
-            await context.github.issues.removeLabel(context.repo({
-              number: issue.number,
-              name: currentLabel.name
-            }))
-          } else if (currentLabel && newLabel === currentLabel.name) {
-            return
-          }
-
+        if (escalation.add.length > 0) {
           await context.github.issues.addLabels(context.repo({
             number: issue.number,
-            labels: [newLabel]
+            labels: escalation.add
           }))
         }
       })

--- a/lib/escalator.js
+++ b/lib/escalator.js
@@ -1,0 +1,51 @@
+const moment = require('moment')
+
+module.exports = class Escalator {
+  constructor (config) {
+    this.config = config
+  }
+
+  escalate (issue, comment) {
+    this.config.escalation.values.sort(this.descByThreshold)
+
+    let lastActivityAt = moment(issue.created_at)
+    if (comment !== undefined) {
+      lastActivityAt = moment(comment.created_at)
+    }
+
+    const age = moment() - lastActivityAt
+
+    let value = this.config.escalation.values.find(value => {
+      if (age > value.threshold * 1000) {
+        return value
+      }
+    })
+
+    let labels = issue.labels.filter(label => {
+      return label.name.startsWith(this.config.escalation.prefix)
+    }).map(label => {
+      return label.name
+    })
+
+    let add = []
+    if (!labels.includes(value.name)) {
+      add.push(value.name)
+    }
+
+    let remove = labels.filter(label => {
+      return label !== value.name
+    })
+
+    return {label: value.name, add: add, remove: remove}
+  }
+
+  descByThreshold (a, b) {
+    if (a.threshold > b.threshold) {
+      return -1
+    }
+    if (a.threshold < b.threshold) {
+      return 1
+    }
+    return 0
+  }
+}


### PR DESCRIPTION
**This includes commits from #13 - make sure that one gets merged first.**

The escalation was only looking at issues and PRs where the author had commented. That means that if an issue or PR came in with no comments, or where some random 3rd party had commented, we wouldn't escalate them. I also discovered that it was incorrectly escalating issues that were `waiting-for/author`. This turned out to be a minor typo on a parameter.

I first implemented escalation as a stand-alone, tested module. I don't know what I'm doing JavaScript-wise, so would appreciate any feedback on best-practices or idioms.

Then I pulled the escalation logic into the `index.js`, which fixed the problems observed. I tested it manually in the apple-pie repo, removing all the escalation labels and watching the correct ones appear:

<img width="816" alt="screen shot 2018-01-28 at 4 17 56 pm" src="https://user-images.githubusercontent.com/276834/35488471-d68d2420-0446-11e8-99c0-223915bd9a80.png">
