### PR TITLE
[WIP] Eliminate unnecessary API calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,18 @@
 const createScheduler = require('probot-scheduler')
+<<<<<<< HEAD
 const Config = require('./lib/config')
 const Escalator = require('./lib/escalator')
 
 module.exports = (robot) => {
   const config = new Config()
   const escalator = new Escalator(config)
+=======
+const moment = require('moment')
+const Config = require('./lib/config')
+
+module.exports = (robot) => {
+  const config = new Config()
+>>>>>>> Pull the new config into the app logic
 
   createScheduler(robot)
 
@@ -13,7 +21,11 @@ module.exports = (robot) => {
 
     const issues = context.github.issues.getForRepo(context.repo({
       state: 'open',
+<<<<<<< HEAD
       labels: config.roles.label({role: 'maintainer'}),
+=======
+      label: config.roles.label({role: 'maintainer'}),
+>>>>>>> Pull the new config into the app logic
       per_page: 100
     }))
 


### PR DESCRIPTION
🚧 🚧 🚧 nothing to see here, folks 🚧 🚧 🚧 

When we get an installation event, we create all the labels (roles and escalation) that the app needs. However, if we try to create a label that already exists we get a 422. The unnecessary call also counts against our rate limit, which is another good reason not to make the call in the first place.

The trade-off, of course, is that we're making at least one extra API call in order to get the labels... so it's debatable how many calls we'll actually save.
