### PR TITLE
Handle the case where author is also a maintainer

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,11 @@ module.exports = (robot) => {
 
   // Maintainer comments/reviews
   robot.on(['issue_comment.created', 'pull_request_review.submitted', 'pull_request_review_comment.created'], async context => {
+    // If the author is a maintainer, then the issue needs attention from a different maintainer.
+    if (isAuthor(context)) {
+      return
+    }
+
     if (await isMaintainer(context)) {
       await context.github.issues.addLabels(context.issue({labels: ['stalebot/waiting-for/author']}))
       await context.github.issues.removeLabel(context.issue({name: 'stalebot/waiting-for/maintainer'}))

--- a/index.js
+++ b/index.js
@@ -89,24 +89,15 @@ module.exports = (robot) => {
     return result
   })
 
-  // Maintainer comments/reviews
-  robot.on(['issue_comment.created', 'pull_request_review.submitted', 'pull_request_review_comment.created'], async context => {
-    // If the author is a maintainer, then the issue needs attention from a different maintainer.
-    if (isAuthor(context)) {
-      return
-    }
-
-    if (await isMaintainer(context)) {
-      await context.github.issues.addLabels(context.issue({labels: ['stalebot/waiting-for/author']}))
-      await context.github.issues.removeLabel(context.issue({name: 'stalebot/waiting-for/maintainer'}))
-    }
-  })
-
-  // Author comments
+  // New comments from participants
   robot.on(['issue_comment.created', 'pull_request_review.submitted', 'pull_request_review_comment.created'], async context => {
     if (isAuthor(context)) {
       await context.github.issues.removeLabel(context.issue({name: 'stalebot/waiting-for/author'}))
       await context.github.issues.addLabels(context.issue({labels: ['stalebot/waiting-for/maintainer']}))
+      // Do not consider authors as maintainers in the context of their own PRs/issues.
+    } else if (await isMaintainer(context)) {
+      await context.github.issues.addLabels(context.issue({labels: ['stalebot/waiting-for/author']}))
+      await context.github.issues.removeLabel(context.issue({name: 'stalebot/waiting-for/maintainer'}))
     }
   })
 }


### PR DESCRIPTION
If a maintainer of a project opens up an issue or a PR, then typically
they want someone else to review and/or respond.

This won't count activity from the author as activity from a maintainer,
even if they happen to be a maintainer.